### PR TITLE
Allows optional tls_cacertfile to be specified.

### DIFF
--- a/templates/default/ldap.conf.erb
+++ b/templates/default/ldap.conf.erb
@@ -26,6 +26,9 @@ tls_checkpeer yes
 <% else -%>
 tls_checkpeer no
 <% end -%>
+<% if node['openldap']['tls_cacertfile'] -%>
+tls_cacertfile <%= node['openldap']['tls_cacertfile'] %>
+<% end -%>
 <% end -%>
 
 pam_password <%= node['openldap']['pam_password'] %>


### PR DESCRIPTION
This will allow the user to set a specific value for the tls_cacertfile directive. This is helpful tls configurations.