### PR TITLE
Add 'openldap/uri' attribute for client configuration.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 
 default['openldap']['basedn'] = "dc=localdomain"
 default['openldap']['server'] = "ldap.localdomain"
+default['openldap']['uri'] = nil
 default['openldap']['tls_enabled'] = true
 default['openldap']['pam_password'] = 'md5'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Configures a server to be an OpenLDAP master, replication slave or client for auth"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.12.11"
+version           "1.13.0"
 recipe            "openldap", "Empty, use one of the other recipes"
 recipe            "openldap::auth", "Set up openldap for user authentication"
 recipe            "openldap::client", "Install openldap client packages"
@@ -29,6 +29,11 @@ attribute "openldap/server",
   :display_name => "OpenLDAP Server",
   :description => "LDAP Server, used for URIs",
   :default => "ldap.domain"
+
+attribute "openldap/uri",
+  :display_name => "OpenLDAP Server URI",
+  :description => "LDAP Server URI in a form 'ldap://ldap1.example.com/ ldap://10.0.0.1:389/'. This attribute is used instead of 'server' for configuring ldap client",
+  :default => nil
 
 attribute "openldap/rootpw",
   :display_name => "OpenLDAP Root Password",

--- a/recipes/auth.rb
+++ b/recipes/auth.rb
@@ -34,6 +34,7 @@ template "/etc/ldap.conf" do
   mode 00644
   owner "root"
   group "root"
+  notifies :restart, "service[ssh]", :delayed
 end
 
 template "#{node['openldap']['dir']}/ldap.conf" do

--- a/templates/default/ldap-ldap.conf.erb
+++ b/templates/default/ldap-ldap.conf.erb
@@ -7,9 +7,13 @@
 # See ldap.conf(5) for details
 # This file should be world readable but not world writable.
 
+<% if node['openldap']['uri'].nil? -%>
+URI ldap://<%= node['openldap']['server'] %>/
+<% else -%>
+URI <%= node['openldap']['uri'] %>
+<% end -%>
 BASE <%= node['openldap']['basedn'] %>
 TLS_REQCERT never
-#URI    ldap://ldap.example.com ldap://ldap-master.example.com:666
 
 #SIZELIMIT      12
 #TIMELIMIT      15

--- a/templates/default/ldap.conf.erb
+++ b/templates/default/ldap.conf.erb
@@ -4,8 +4,12 @@
 # Managed by Chef
 #
 
+<% if node['openldap']['uri'].nil? -%>
 host <%= node['openldap']['server'] %>
 port 389
+<% else -%>
+uri <%= node['openldap']['uri'] %>
+<% end -%>
 bind_policy soft
 
 ldap_version 3

--- a/templates/default/libnss-ldap.conf.erb
+++ b/templates/default/libnss-ldap.conf.erb
@@ -3,10 +3,13 @@
 #
 # Managed by Chef
 #
-# $Id:$
 
+<% if node['openldap']['uri'].nil? -%>
 host <%= node['openldap']['server'] %>
 port 389
+<% else -%>
+uri <%= node['openldap']['uri'] %>
+<% end -%>
 #bind_policy soft
 nss_reconnect_tries 2
 ldap_version 3
@@ -14,15 +17,17 @@ ldap_version 3
 # Where to find data
 base <%= node['openldap']['basedn'] %>
 scope sub
-nss_base_passwd ou=people,<%= node['openldap']['basedn'] %>
-nss_base_shadow ou=people,<%= node['openldap']['basedn'] %>
-nss_base_group ou=group,<%= node['openldap']['basedn'] %>
+nss_base_passwd ou=<%= node['openldap']['passwd_ou'] %>,<%= node['openldap']['basedn'] %>
+nss_base_shadow ou=<%= node['openldap']['shadow_ou'] %>,<%= node['openldap']['basedn'] %>
+nss_base_group ou=<%= node['openldap']['group_ou'] %>,<%= node['openldap']['basedn'] %>
+nss_base_automount ou=<%= node['openldap']['automount_ou'] %>,<%= node['openldap']['basedn'] %>
 
+<% if node['openldap']['tls_enabled'] -%>
 # TLS Options
 ssl start_tls
-
 <% if node['openldap']['tls_checkpeer'] -%>
 tls_checkpeer yes
 <% else -%>
 tls_checkpeer no
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Added `openldap/uri` attribute to be used instead of deprecated (and discouraged) server/port combination. The `ldap/uri` attribute is set to `nil` by default and all relevant templates have been updated to only use `uri` attribute if specified and fall back to original behavior otherwise. This makes this change 100% backward compatible.