### PR TITLE
Add Password Policy and audit log overlays as configurable items

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Be aware of the attributes used by this cookbook and adjust the defaults for you
 
 - `openldap['schemas']` - Array of ldap schema file names to load
 - `openldap['modules']` - Array of slapd modules names to load
+- `openldap['ppolicy']` - Set this to true to enable the password policy overlay. Defaults to false
+- `openldap['ppolicy_hash_cleartext']` - If the password policy overlay is enabled, set ppolicy_hash_cleartext. Defaults to true
+- `openldap['ppolicy_use_lockout']` - If the password policy overlay is enabled, set ppolicy_use_lockout. Defaults to true
+- `openldap['auditlog']` - Set this to true to enable the audit log overlay. Defaults to false
+- `openldap['auditlog_file']` - If the audit log overlay is enabled, this configures the file to write to. Defaults to /var/log/openldap/audit.log (note - the directory this is in must be writable by the ldap user)
 - `openldap['slapd_type']` - master | slave
 - `openldap['slapd_rid']` - unique integer ID, required if type is slave.
 - `openldap['slapd_master']` - hostname of slapd master, attempts to search for slapd_type master.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,7 +59,12 @@ when 'freebsd'
   default['openldap']['modules'] = %w(back_mdb)
   default['openldap']['database'] = 'mdb'
 else
-  default['openldap']['modules'] = %w(back_hdb)
+  if node['platform'] == 'centos'
+    default['openldap']['modules'] = []
+  else
+    default['openldap']['modules'] = %w(back_hdb)
+  end
+
   default['openldap']['database'] = 'hdb'
 end
 
@@ -120,6 +125,11 @@ default['openldap']['preseed_dir'] = '/var/cache/local/preseeding'
 default['openldap']['pam_password'] = 'md5'
 default['openldap']['loglevel'] = 'sync config'
 default['openldap']['schemas'] = %w(core.schema cosine.schema nis.schema inetorgperson.schema)
+default['openldap']['ppolicy'] = false
+default['openldap']['ppolicy_hash_cleartext'] = true
+default['openldap']['ppolicy_use_lockout'] = true
+default['openldap']['auditlog'] = nil
+default['openldap']['auditlog_file'] = '/var/log/openldap/audit.log'
 
 # dynamically generated pam.d files
 # additional attributes added here will be added to the common-account, common-auth, common-password, and common-session files

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,6 +19,23 @@
 #
 include_recipe 'openldap::client'
 
+# if password policy overlay is enabled,
+# then force the ppolicy schema + modules
+schemas = node['openldap']['schemas'].to_a
+modules = node['openldap']['modules'].to_a
+
+modules << 'syncprov' if node['openldap']['slapd_type'] == 'master'
+
+if node['openldap']['ppolicy']
+  schemas << 'ppolicy.schema'
+  modules << 'ppolicy'
+end
+
+modules << 'auditlog' if node['openldap']['auditlog']
+
+node.set['openldap']['schemas'] = schemas.sort.uniq
+node.set['openldap']['modules'] = modules.sort.uniq
+
 if node['platform_family'] != 'freebsd'
   package node['openldap']['packages']['bdb'] do
     action node['openldap']['package_install_action']

--- a/templates/default/slapd.conf.erb
+++ b/templates/default/slapd.conf.erb
@@ -31,14 +31,11 @@ argsfile        <%= node['openldap']['run_dir'] %>/slapd.args
 # Read slapd.conf(5) for possible values
 loglevel        <%= node['openldap']['loglevel'] %>
 
-<% unless node['platform'] == "centos" -%>
+<% unless node['openldap']['modules'].empty? -%>
 # Where the dynamically loaded modules are stored
 modulepath       <%= node['openldap']['module_dir'] %>
 <% node['openldap']['modules'].sort.each do |mod| -%>
 moduleload       <%= mod %>
-<% end -%>
-<% if node['openldap']['slapd_type'] == "master" -%>
-moduleload       syncprov
 <% end -%>
 <% end -%>
 
@@ -114,6 +111,24 @@ syncrepl rid=<%= node['openldap']['slapd_rid'] %>
 <%   when String, Integer -%>
 <%=    key %> <%= value %>
 <%   end -%>
+<% end -%>
+
+<% if node['openldap']['ppolicy'] -%>
+### Load password overlay
+overlay ppolicy
+ppolicy_default "cn=passwordDefault,ou=Policies,<%= node['openldap']['basedn'] %>"
+<% if node['openldap']['ppolicy_hash_cleartext'] -%>
+ppolicy_hash_cleartext
+<% end -%>
+<% if node['openldap']['ppolicy_use_lockout'] -%>
+ppolicy_use_lockout
+<% end -%>
+<% end -%>
+
+<% if node['openldap']['auditlog'] -%>
+### Load audit log overlay
+overlay auditlog
+auditlog <%= node['openldap']['auditlog_file'] %>
 <% end -%>
 
 # The userPassword by default can be changed


### PR DESCRIPTION
Add ppolicy and auditlog overlays as configurable options. Tested on CentOS 7.

The defaults behaviour should not have changed.
