### PR TITLE
recipe using 'system_user' not 'system_acct'

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -76,14 +76,14 @@ if node['platform_family'] == 'debian'
 
   directory "#{node['openldap']['dir']}/slapd.d" do
     recursive true
-    owner node['openldap']['system_user']
+    owner node['openldap']['system_acct']
     group node['openldap']['system_group']
     action :create
   end
 
   execute 'slapd-config-convert' do
     command "slaptest -f #{node['openldap']['dir']}/slapd.conf -F #{node['openldap']['dir']}/slapd.d/"
-    user node['openldap']['system_user']
+    user node['openldap']['system_acct']
     action :nothing
     notifies :start, 'service[slapd]', :immediately
   end
@@ -91,7 +91,7 @@ if node['platform_family'] == 'debian'
   template "#{node['openldap']['dir']}/slapd.conf" do
     source 'slapd.conf.erb'
     mode '0640'
-    owner node['openldap']['system_user']
+    owner node['openldap']['system_acct']
     group node['openldap']['system_group']
     notifies :stop, 'service[slapd]', :immediately
     notifies :run, 'execute[slapd-config-convert]'
@@ -100,7 +100,7 @@ else
   template "#{node['openldap']['dir']}/slapd.conf" do
     source 'slapd.conf.erb'
     mode '0640'
-    owner node['openldap']['system_user']
+    owner node['openldap']['system_acct']
     group node['openldap']['system_group']
     notifies :restart, 'service[slapd]'
   end


### PR DESCRIPTION
recipe is expecting an attribute named "system_user" but attributes are configured to provide "system_acct".

obvious fix.