### PR TITLE
Add TLSCipherSuite to slapd.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Be aware of the attributes used by this cookbook and adjust the defaults for you
 - `openldap['ssl_cert_source_path']` - The path in the cookbook to find the ssl cert file.
 - `openldap['ssl_key_source_cookbook']` - The cookbook to find the ssl key.  Defaults to this cookbook
 - `openldap['ssl_key_source_path']` - The path in the cookbook to find the ssl key file.
+- `openldap['ssl_ciphersuite']` - The OpenSSL cipher suite specification to use. Defaults to none (use system default)
 - `openldap['cafile']` - Your certificate authority's certificate (or intermediate authorities), if needed.
 
 Recipes

--- a/templates/default/slapd.conf.erb
+++ b/templates/default/slapd.conf.erb
@@ -14,6 +14,9 @@ TLSCertificateKeyFile  <%= node['openldap']['ssl_key'] %>
 <% if node['openldap']['cafile'] -%>
 TLSCACertificateFile   <%= node['openldap']['cafile'] %>
 <% end -%>
+<% if node['openldap']['ssl_ciphersuite'] -%>
+TLSCipherSuite         <%= node['openldap']['ssl_ciphersuite'] %>
+<% end -%>
 <% end -%>
 
 # Schema and objectClass definitions


### PR DESCRIPTION
Has to be explicitly enabled - default is not to add the line to slapd.conf (which is current default)