### PR TITLE
Split out NSS configuration from the auth recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -69,3 +69,18 @@ suites:
      shadow_ou: ninjas
      group_ou: pirates
      automount_ou: barge
+- name: nss_test
+  run_list:
+  - recipe[openldap::nss]
+  attributes:
+    openldap:
+      server_uri: 'ldap://ldap.example.com'
+      basedn: "dc=example, dc=com"
+      nss_base:
+        passwd:
+          - "ou=people, dc=example, dc=com"
+        shadow:
+          - "ou=people, dc=example, dc=com"
+        group:
+          - "ou=group, dc=example, dc=com"
+      tls_enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,22 +75,26 @@ when 'debian'
                                            end
   default['openldap']['packages']['client_pkg'] = 'ldap-utils'
   default['openldap']['packages']['srv_pkg'] = 'slapd'
-  default['openldap']['packages']['auth_pkgs'] = %w(libnss-ldap libpam-ldap)
+  default['openldap']['packages']['nss'] = 'libnss-ldap'
+  default['openldap']['packages']['auth_pkgs'] = %w(libpam-ldap)
 when 'rhel'
   default['openldap']['packages']['bdb'] = 'db4-utils'
   default['openldap']['packages']['client_pkg'] = 'openldap-clients'
   default['openldap']['packages']['srv_pkg'] = 'openldap-servers'
+  default['openldap']['packages']['nss'] = %w(nss-pam-ldapd)
   default['openldap']['packages']['auth_pkgs'] = %w(nss-pam-ldapd)
 when 'freebsd'
   default['openldap']['packages']['bdb'] = 'libdbi'
   default['openldap']['packages']['client_pkg'] = 'openldap-client'
   default['openldap']['packages']['srv_pkg'] = 'openldap-server'
+  default['openldap']['packages']['nss'] = 'openldap-client'
   default['openldap']['packages']['auth_pkgs'] = %w(pam_ldap)
 else
   default['openldap']['packages']['bdb'] = 'db-utils'
   default['openldap']['packages']['client_pkg'] = 'ldap-utils'
   default['openldap']['packages']['srv_pkg'] = 'slapd'
-  default['openldap']['packages']['auth_pkgs'] = %w(libnss-ldap libpam-ldap)
+  default['openldap']['packages']['nss'] = 'libnss-ldap'
+  default['openldap']['packages']['auth_pkgs'] = %w(libpam-ldap)
 end
 
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,14 +4,15 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures a server to be an OpenLDAP master, replication slave or client for auth'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.1'
+version           '2.2.3'
 
 recipe            'openldap',         'Empty, use one of the other recipes'
+recipe            'openldap::nss',    'Set up openldap for NSS'
 recipe            'openldap::auth',   'Set up openldap for user authentication'
 recipe            'openldap::client', 'Install openldap client packages'
 recipe            'openldap::server', 'Set up openldap to be a slapd server'
 recipe            'openldap::slave',  'Uses search to set replication slave attributes'
-recipe            'openldap::master', 'Use on nodes that should be a slapd master'
+recipe            'openldap::master',   'Use on nodes that should be a slapd master'
 
 %w(ubuntu debian freebsd redhat centos amazon scientific oracle).each do |os|
   supports os


### PR DESCRIPTION
Allow configuration of just NSS and the LDAP client without configuring authentication
