### PR TITLE
Update default slapd config to support ldaps if ssl cert are installed

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,7 @@ when 'debian'
   default['openldap']['module_dir'] = '/usr/lib/ldap'
   default['openldap']['system_acct'] = 'openldap'
   default['openldap']['system_group'] = 'openldap'
+  default['openldap']['enable_ldaps'] = false
 when 'freebsd'
   default['openldap']['dir'] = '/usr/local/etc/openldap'
   default['openldap']['run_dir'] = '/var/run/openldap'

--- a/templates/default/default_slapd.erb
+++ b/templates/default/default_slapd.erb
@@ -27,7 +27,11 @@ SLAPD_PIDFILE=
 # sockets.
 # Example usage:
 # SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
+<% if node['openldap']['ssl_key'] and node['openldap']['ssl_cert'] -%>
+SLAPD_SERVICES="ldap:/// ldapi:/// ldaps:///"
+<% else -%>
 SLAPD_SERVICES="ldap:/// ldapi:///"
+<% end -%>
 
 # If SLAPD_NO_START is set, the init script will not start or restart
 # slapd (but stop will still work).  Uncomment this if you are

--- a/templates/default/default_slapd.erb
+++ b/templates/default/default_slapd.erb
@@ -27,7 +27,7 @@ SLAPD_PIDFILE=
 # sockets.
 # Example usage:
 # SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
-<% if node['openldap']['ssl_key'] and node['openldap']['ssl_cert'] -%>
+<% if node['openldap']['enable_ldaps'] -%>
 SLAPD_SERVICES="ldap:/// ldapi:/// ldaps:///"
 <% else -%>
 SLAPD_SERVICES="ldap:/// ldapi:///"


### PR DESCRIPTION
### Description

Updated default slapd config template to support ldaps protocol if the ssl cert is defined.
### Issues Resolved

None.
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
