### PR TITLE
Resolve contention with apt cookbook on the mode of preseeding directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the openldap cookbook.
 
+## v3.0.2 (2017-03-27)
+- Change `/var/cache/local/preseeding` resource configuration to be mode '0755'
+
 ## v3.0.1 (2017-03-27)
 - Update metadata to improve search query on supermarket for ldap.
 - Standardize license string in metadata.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Installs and configures OpenLDAP (slapd) an open source implementation of LDAP.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '3.0.1'
+version           '3.0.2'
 
 recipe            'openldap::default', 'Install and configure OpenLDAP'
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -14,7 +14,7 @@ action :install do
     directory node['openldap']['preseed_dir'] do
       action :create
       recursive true
-      mode '0700'
+      mode '0755'
       owner 'root'
       group node['root_group']
     end


### PR DESCRIPTION
### Description

While the mode for the preseeding directory for openldap has been `700` for many years, the apt cookbook configures it to be `755`, and when mysql configured this it used to configure it as `755`. The right thing might be to remove this particular resource, or modify it to have a specific directory per application. For now, this will solve the problem for folks using cookbooks apt and openldap, while causing a new cookbook to be downloaded with no change for other platforms.


### Issues Resolved

Issue #85 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
