### PR TITLE
Fix compatibility with 12.5/12.6 and update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configures a server to be an OpenLDAP master or replication slave. Also includes
 
 ### Chef
 
-- Chef 12.1+
+- Chef 12.5+
 
 ### Cookbooks
 
@@ -38,8 +38,7 @@ $ slappasswd -s "secretsauce"
 {SSHA}6BjlvtSbVCL88li8IorkqMSofkLio58/
 ```
 
-Set this via a node/role/env attribute or in a wrapper cookbook with an encrypted data_bag. OpenLDAP will fail to start
-if this is not set.
+Set this via a node/role/env attribute or in a wrapper cookbook with an encrypted data_bag. OpenLDAP will fail to start if this is not set.
 
 ### Install/Upgrade
 
@@ -52,9 +51,7 @@ if this is not set.
 
 ### TLS/SSL
 
-If `openldap['ldaps_enabled']` or `openldap['tls_enabled']` are set, then `openldap['tls_cert']`
-and `openldap['tls_key']` must also be set and the files must exist prior to execution. Depending
-on the certificates, `openldap['tls_cafile']` may also need to be set. See the test cookbook for an example.
+If `openldap['ldaps_enabled']` or `openldap['tls_enabled']` are set, then `openldap['tls_cert']` and `openldap['tls_key']` must also be set and the files must exist prior to execution. Depending on the certificates, `openldap['tls_cafile']` may also need to be set. See the test cookbook for an example.
 
 - `openldap['ldaps_enabled']` - listen on LDAPS (636) true | false (default)
 - `openldap['tls_enabled']` - true | false (default)

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,4 +16,4 @@ depends 'dpkg_autostart'
 
 source_url 'https://github.com/chef-cookbooks/openldap'
 issues_url 'https://github.com/chef-cookbooks/openldap/issues'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 12.5' if respond_to?(:chef_version)

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -38,7 +38,7 @@ action :install do
   end
 end
 
-action_class do
+action_class.class_eval do
   def server_package
     case node['platform_family']
     when 'debian'


### PR DESCRIPTION
The resource requires 12.5+, but won’t work on < 12.7 w/o the class_eval part.

Signed-off-by: Tim Smith <tsmith@chef.io>