### PR TITLE
remove extra by, invalid syntax that breaks non-admin read

### DIFF
--- a/templates/default/slapd.conf.erb
+++ b/templates/default/slapd.conf.erb
@@ -153,6 +153,6 @@ access to dn.base="" by * read
 access to *
         by group.exact="cn=administrators,<%= node['openldap']['basedn'] %>" write
 <% if node['openldap']['slapd_type'] == "provider" -%>
-        by by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
+        by dn="<%= node['openldap']['syncrepl_cn'] %>,<%= node['openldap']['basedn'] %>" read
 <% end -%>
         by * read


### PR DESCRIPTION
### Description

There's an extra "by" in the read declaration of slapd.conf, which breaks non-admin read permissions. This PR deletes the extra "by", permitting read to function as intended. As a typo fix I think this fits the definition of an "obvious fix" per the [contribution policy](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD#chef-obvious-fix-policy).

### Issues Resolved

https://github.com/chef-cookbooks/openldap/issues/92

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [n/a] New functionality includes testing.
- [n/a] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
